### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through a stack trace

### DIFF
--- a/app/api/subscribe+api.ts
+++ b/app/api/subscribe+api.ts
@@ -126,7 +126,12 @@ export async function POST(request: Request) {
       );
     }
   } catch (error) {
-    console.error('Subscription error:', error);
+    // Log stack trace for server-side debugging, don't expose to client
+    if (error instanceof Error && error.stack) {
+      console.error('Subscription error:', error.stack);
+    } else {
+      console.error('Subscription error:', error);
+    }
     
     // Determine appropriate status code
     const statusCode = error instanceof Error && 'statusCode' in error 
@@ -148,10 +153,7 @@ export async function POST(request: Request) {
     return new Response(
       JSON.stringify({ 
         error: errorMessage,
-        code: statusCode,
-        details: process.env.NODE_ENV === 'development' && error instanceof Error 
-          ? error.stack 
-          : undefined
+        code: statusCode
       }),
       { 
         status: statusCode,


### PR DESCRIPTION
Potential fix for [https://github.com/edcalderon/hashpass.tech/security/code-scanning/1](https://github.com/edcalderon/hashpass.tech/security/code-scanning/1)

To fix this, we should ensure that API responses **never** leak stack trace information to the client, regardless of environment. Error stack traces should only be logged on the server side, and never sent to users over HTTP. In the current code, the `details` property is set to `error.stack` in development. We need to remove this field from the response. Instead, we can log stack traces to the server console for debugging. The change affects lines 152–154 inside the response object, and nearby: Remove the `details` field, and ensure error stack is only logged using `console.error`, not returned to the user.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
